### PR TITLE
Update hab download link and recommended disk size

### DIFF
--- a/examples/HabitatBuilderWithS3RDS.md
+++ b/examples/HabitatBuilderWithS3RDS.md
@@ -8,7 +8,7 @@ These instructions will allow a highly-available on-premise depot installation l
 * New Instance:
   * 16 Cores
   * 32 GB RAM
-  * /hab partitioned to a 20 GB volume
+  * /hab partitioned to a 100 GB volume
   * /tmp partitioned to a 50 GB volume
   * Communication opened on 443, 80, Postgres RDS port
   * Able to get root access
@@ -22,7 +22,7 @@ These instructions will allow a highly-available on-premise depot installation l
 1. Download the Zip archive of the on-prem-builder repo:<br />
 `curl -LO https://github.com/habitat-sh/on-prem-builder/archive/master.zip`
 2. Download the Chef Habitat cli tool:<br />
-`curl -Lo hab.tar.gz https://api.bintray.com/content/habitat/stable/linux/x86_64/hab-%24latest-x86_64-linux.tar.gz`
+`curl -Lo hab.tar.gz https://packages.chef.io/files/stable/habitat/latest/hab-x86_64-linux.tar.gz`
 3. From the zip archive, install the hab binary somewhere in $PATH and ensure it has execute permissions:<br />
 `sudo chmod 755 /usr/bin/hab`<br />
 `sudo hab license accept # accepts the license`<br />


### PR DESCRIPTION
This updates the download URL for Habitat to packages.chef.io.  We haven't published to bintray since pre-1.0, so any version coming out of there should be considered unsupported.

In addition, the recommended volume size should be 100GB,  20GB would cover one update of core-plans and builder. Any additional updates would most likely fill the disk, and a customer that is a prolific author would also likely fill up a 20GB volume. 

A lot of this is duplicated from the docs in the on-prem-depo repository.  If there are differences or missing information, it would be great to feed that back into the upstream repo and point there so we don't need to track the information in multiple places.  

Finally, the recommended way to install Builder on-prem should be through the A2 installation. I'm unsure of the external db/s3 support there, so this may still be the recommended path in the near term if a customer needs external db/s3 support.

Signed-off-by: Scott Macfarlane <smacfarlane@chef.io>