### PR TITLE
gitlab examples updates

### DIFF
--- a/examples/pipelines/GitLabCI/cookbook_berks.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/cookbook_berks.gitlab-ci.yml
@@ -1,7 +1,11 @@
-image: "chef/chefdk"
+image: "chef/chefworkstation"
 
 services:
   - docker:dind
+
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  CHEF_LICENSE: accept
 
 before_script:
   - echo $(admin-pem) | base64 -d > ~/.chef/admin.pem
@@ -16,19 +20,27 @@ cookstyle:
   stage: test
   script:
     - chef exec cookstyle .
+  variables:
+    <<: *shared_variables
 
 chefspec:
   stage: test
   script:
     - chef exec rspec .
+  variables:
+    <<: *shared_variables
 
-chefspec:
+kitchen_test:
   stage: test
   script:
     - chef exec kitchen test
+  variables:
+    <<: *shared_variables
 
 publish:
   stage: publish
   script:
     - berks install
     - berks upload --ssl-verify=false
+  variables:
+    <<: *shared_variables

--- a/examples/pipelines/GitLabCI/cookbook_effortless.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/cookbook_effortless.gitlab-ci.yml
@@ -1,13 +1,16 @@
-image: "chef/chefdk"
+image: "chef/chefworkstation"
 
 services:
   - docker:dind
 
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  HAB_LICENSE: accept
+  CHEF_LICENSE: accept
+
 before_script:
   - apt-get update
   - apt-get install -y curl wget
-  - curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
-  - hab license accept
   - echo $sig | base64 -d > /hab/cache/keys/origin-20191217002439.pub
   - echo $key | base64 -d > /hab/cache/keys/origin-20191217002439.sig.key
   - mkdir - p /hab/etc
@@ -24,16 +27,22 @@ cookstyle:
   stage: test
   script:
     - chef exec cookstyle .
+  variables:
+    <<: *shared_variables
 
 chefspec:
   stage: test
   script:
     - chef exec rspec .
+  variables:
+    <<: *shared_variables
 
-chefspec:
+kitchen_test:
   stage: test
   script:
     - chef exec kitchen test
+  variables:
+    <<: *shared_variables
 
 create_artifact:
   stage: build
@@ -42,6 +51,8 @@ create_artifact:
       - results/
   script:
     - hab pkg build habitat/.
+  variables:
+    <<: *shared_variables
 
 publish_artifact:
   stage: publish
@@ -51,6 +62,8 @@ publish_artifact:
   script:
     - source results/last_build.env
     - hab pkg upload results/$pkg_artifact
+  variables:
+    <<: *shared_variables
 
 promote_stg:
   stage: promote_stg
@@ -60,6 +73,8 @@ promote_stg:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident stg
+  variables:
+    <<: *shared_variables
   when: manual
 
 promote_prod:
@@ -70,4 +85,6 @@ promote_prod:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident prod
+  variables:
+    <<: *shared_variables
   when: manual

--- a/examples/pipelines/GitLabCI/cookbook_policyfile.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/cookbook_policyfile.gitlab-ci.yml
@@ -1,7 +1,11 @@
-image: "chef/chefdk"
+image: "chef/chefworkstation"
 
 services:
   - docker:dind
+
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  CHEF_LICENSE: accept
 
 before_script:
   - echo $(admin-pem) | base64 -d > ~/.chef/admin.pem
@@ -18,16 +22,22 @@ cookstyle:
   stage: test
   script:
     - chef exec cookstyle .
+  variables:
+    <<: *shared_variables
 
 chefspec:
   stage: test
   script:
     - chef exec rspec .
+  variables:
+    <<: *shared_variables
 
-chefspec:
+test_kitchen:
   stage: test
   script:
     - chef exec kitchen test
+  variables:
+    <<: *shared_variables
 
 create_artifact:
   stage: build
@@ -36,6 +46,8 @@ create_artifact:
       - Policyfile.lock.json
   script:
     - chef install
+  variables:
+    <<: *shared_variables
 
 publish_artifact:
   stage: publish
@@ -44,6 +56,8 @@ publish_artifact:
       - Policyfile.lock.json
   script:
     - chef push dev
+  variables:
+    <<: *shared_variables
 
 promote_stg:
   stage: promote_stg
@@ -52,6 +66,8 @@ promote_stg:
       - Policyfile.lock.json
   script:
     - chef push stg
+  variables:
+    <<: *shared_variables
   when: manual
 
 promote_prod:
@@ -61,4 +77,6 @@ promote_prod:
       - Policyfile.lock.json
   script:
     - chef push prod
+  variables:
+    <<: *shared_variables
   when: manual

--- a/examples/pipelines/GitLabCI/plan.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/plan.gitlab-ci.yml
@@ -1,12 +1,14 @@
-image: "ubuntu"
+image: "chef/chefworkstation"
 services:
   - docker:dind
+
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  HAB_LICENSE: accept
 
 before_script:
   - apt-get update
   - apt-get install -y curl wget
-  - curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
-  - hab license accept
   - echo $sig | base64 -d > /hab/cache/keys/origin-20191217002439.pub
   - echo $key | base64 -d > /hab/cache/keys/origin-20191217002439.sig.key
   - mkdir - p /hab/etc
@@ -23,6 +25,8 @@ lint:
   stage: test
   script:
     - echo "You should really have some testing for this app..."
+  variables:
+    <<: *shared_variables
 
 create_artifact:
   stage: build
@@ -31,6 +35,8 @@ create_artifact:
       - results/
   script:
     - hab pkg build habitat/.
+  variables:
+    <<: *shared_variables
 
 publish_artifact:
   stage: publish
@@ -40,6 +46,8 @@ publish_artifact:
   script:
     - source results/last_build.env
     - hab pkg upload results/$pkg_artifact
+  variables:
+    <<: *shared_variables
 
 promote_stg:
   stage: promote_stg
@@ -49,6 +57,8 @@ promote_stg:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident stg
+  variables:
+    <<: *shared_variables
   when: manual
 
 promote_prod:
@@ -59,4 +69,6 @@ promote_prod:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident prod
+  variables:
+    <<: *shared_variables
   when: manual

--- a/examples/pipelines/GitLabCI/profile_audit.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/profile_audit.gitlab-ci.yml
@@ -1,7 +1,11 @@
-image: "chef/chefdk"
+image: "chef/chefworkstation"
 
 services:
   - docker:dind
+
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  CHEF_LICENSE: accept
 
 before_script:
   - echo $(admin-pem) | base64 -d > ~/.chef/admin.pem
@@ -15,11 +19,14 @@ lint:
   stage: test
   script:
     - inspec check .
+  variables:
+    <<: *shared_variables
 
 publish_artifact:
   stage: publish
-
   script:
     - inspec compliance login $AUTOMATE_SERVER_NAME --insecure --user=$AUTOMATE_USER --ent=$AUTOMATE_ENTERPRISE --dctoken=$DC_TOKEN
     - inspec compliance upload . --overwrite
     - inspec compliance logout
+  variables:
+    <<: *shared_variables

--- a/examples/pipelines/GitLabCI/profile_effortless.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/profile_effortless.gitlab-ci.yml
@@ -1,12 +1,15 @@
-image: "ubuntu"
+image: "chef/chefworkstation"
 services:
   - docker:dind
+
+# Shared variables which we'll attach to jobs
+.shared_variables: &shared_variables
+  HAB_LICENSE: accept
+  CHEF_LICENSE: accept
 
 before_script:
   - apt-get update
   - apt-get install -y curl wget
-  - curl https://raw.githubusercontent.com/habitat-sh/habitat/master/components/hab/install.sh | bash
-  - hab license accept
   - echo $sig | base64 -d > /hab/cache/keys/origin-20191217002439.pub
   - echo $key | base64 -d > /hab/cache/keys/origin-20191217002439.sig.key
   - mkdir - p /hab/etc
@@ -23,6 +26,8 @@ lint:
   stage: test
   script:
     - inspec check .
+  variables:
+    <<: *shared_variables
 
 create_artifact:
   stage: build
@@ -31,6 +36,8 @@ create_artifact:
       - results/
   script:
     - hab pkg build habitat/.
+  variables:
+    <<: *shared_variables
 
 publish_artifact:
   stage: publish
@@ -40,6 +47,8 @@ publish_artifact:
   script:
     - source results/last_build.env
     - hab pkg upload results/$pkg_artifact
+  variables:
+    <<: *shared_variables
 
 promote_stg:
   stage: promote_stg
@@ -49,6 +58,8 @@ promote_stg:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident stg
+  variables:
+    <<: *shared_variables
   when: manual
 
 promote_prod:
@@ -59,4 +70,6 @@ promote_prod:
   script:
     - source results/last_build.env
     - hab pkg promote $pkg_ident prod
+  variables:
+    <<: *shared_variables
   when: manual

--- a/examples/pipelines/GitLabCI/server_objects.gitlab-ci.yml
+++ b/examples/pipelines/GitLabCI/server_objects.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: "chef/chefdk"
+image: "chef/chefworkstation"
 
 services:
   - docker:dind

--- a/examples/pipelines/PipelineDetails.md
+++ b/examples/pipelines/PipelineDetails.md
@@ -37,7 +37,7 @@ Notes:
 
 * Legacy Berks pattern
   * ADO - Chef publishes an extension for ADO that simplifies managing the Chef server info and secrets. Our examples use these extensions whenever possible. More info [here](https://github.com/chef-partners/azuredevops-chef/wiki/getting-started).
-  * GitLab-CI - These examples leverage the `chef/chefdk` docker image to reduce the effort needed to set up the Chef kit. We also need to set up two variables (`admin-pem` and `knife-rb`) in `Settings > CI/CD > Variables` in each project.
+  * GitLab-CI - These examples leverage the `chef/chefworkstation` docker image to reduce the effort needed to set up the Chef kit. We also need to set up two variables (`admin-pem` and `knife-rb`) in `Settings > CI/CD > Variables` in each project.
   * Jenkins - Since Jenkins vary soo much, these example assume that ChefDK or Chef Workstation are installed on the Jenkins server.
 * Policyfile pattern
   * ADO - We continue to use the Chef extensions for several tasks; however, the extension doesn't support policyfiles. For the steps that interact directly with the policyfile, we call the `chef` command directly. We also fetch the `admin.pem` and `knife.rb` from Azure Key Vault.
@@ -45,7 +45,7 @@ Notes:
   * Jenkins - Same config as Berks pattern
 * Modern Effortless pattern
   * ADO - We'll use the Chef Server extensions to test the cookbook. Chef also has an extension for Habitat which we'll use for several tasks. More info [here](https://github.com/chef-partners/azuredevops-habitat/wiki/getting-started).
-  * GitLab-CI - We'll use the `chef/chefdk` image here as well. We'll also install Habitat at runtime. in addition to the variables above, we'll need to configure  thee more: `sig`, `key`, `cli`. These are for the Habitat signing keys along with the `cli.toml` that provide origin and token info for working with BLDR.
+  * GitLab-CI - We'll use the `chef/chefworkstation` image here as well which also includes Habitat binaries. In addition to the variables above, we'll need to configure three more: `sig`, `key`, `cli`. These are for the Habitat signing keys along with the `cli.toml` that provide origin and token info for working with BLDR.
   * Jenkins - Along with needing ChefDK/Chef Workstation, Habitat will need to be installed. You'll also need the additional variables for Habitat.
 
 ### Data bags, Environments, and Roles


### PR DESCRIPTION
* updates from chefdk to chefworkstation for container image
* Removes Habitat install step from `before_script` in Gitlab pipeline examples since it is included in the `chef/chefworkstation` image.
* adds shared variables to gitlab pipelines

Signed-off-by: Collin McNeese <cmcneese@chef.io>