### PR TITLE
idp-initiated SAML logins do not work

### DIFF
--- a/examples/README_FIRST_A2SAML
+++ b/examples/README_FIRST_A2SAML
@@ -1,0 +1,5 @@
+As of September 15, 2021, idp-initiated SAML logins do not work from any idp/browser to Automate 2
+
+https://github.com/chef/automate/pull/5735
+
+Follow https://chef-software.ideas.aha.io/ideas/AUTO-I-59 for updates, to see if this has changed.


### PR DESCRIPTION
automate-dex cannot accept idp-initiated logins currently, only sp-initiated.